### PR TITLE
Removed UPF endpoint from others

### DIFF
--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -30,7 +30,7 @@
     in question must have been harvested previously. If any of these conditions
     is not fulfilled, this setting has no effect.-->
     <incremental>false</incremental>
-    
+
     <scenario>ListRecords</scenario>
   </settings>
 
@@ -54,7 +54,7 @@
       <action type="transform" file="resources/addOAISetName.xsl" cache="cache"/>
       <action type="split"/>
       <action type="save" dir="rec" suffix=".xml"/>
-      <action type="transform" file="https://raw.githubusercontent.com/menzowindhouwer/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>
       <action type="save" dir="cmdi-1_1" suffix=".xml"/>
       <action type="transform" file="https://infra.clarin.eu/CMDI/1.x/upgrade/cmd-record-1_1-to-1_2.xsl" cache="cache"/>
       <action type="save" dir="cmdi-1_2" suffix=".xml"/>
@@ -64,7 +64,7 @@
       <action type="transform" file="resources/addOAISetName.xsl" cache="cache"/>
       <action type="split"/>
       <action type="save" dir="rec" suffix=".xml"/>
-      <action type="transform" file="https://raw.githubusercontent.com/menzowindhouwer/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>
       <action type="save" dir="cmdi-1_1" suffix=".xml"/>
       <action type="transform" file="https://infra.clarin.eu/CMDI/1.x/upgrade/cmd-record-1_1-to-1_2.xsl" cache="cache"/>
       <action type="save" dir="cmdi-1_2" suffix=".xml"/>
@@ -74,111 +74,32 @@
 
   <!-- ### list of providers ### -->
   <providers>
-    <!--
-	Example with set specification:
-      -->
-      <!--
-    <provider url="http://www.dummy.example.only/" name="TEST">
-      <set>abc</set>
-      <set>xyz</set>
-    </provider>
-      -->
-    
-    <provider url="http://www.language-archives.org/hosted/acl.xml" static="true"
-	      name="A Digital Archive of Research Papers in Computational Linguistics"/>
-    <provider url="http://www.language-archives.org/hosted/ailla.xml" static="true"
-	      name="Archive of the Indigenous Languages of Latin America"/>
-    <provider url="http://www.language-archives.org/hosted/atilf.xml" static="true"/>
+    <provider url="http://www.language-archives.org/hosted/acl.xml" static="true" name="A Digital Archive of Research Papers in Computational Linguistics"/>
     <provider url="http://cla.berkeley.edu/olac.xml" static="true"/>
-    <provider url="https://metadata-wg.mannlib.cornell.edu/clal.xml" static="true"/>
-    <!--<provider url="http://victoria.linguistlist.org/php4/ore/XMLnamespacefiles/CoCoSP/CoCoSP.xml"
-	      static="true"
-	      name="Comparative Corpus of Spoken Portuguese"/>-->
-    <provider url="http://www.elra.info/elrac/elra_catalogue.xml" static="true"
-	      name="European Language Resources Association"/>
-    <provider url="http://archive.ethnologue.com/oai2.asp" scenario="ListIdentifiers"/>
-    <provider url="http://www.language-archives.org/hosted/AcademiaSinica.xml" static="true"
-	      name="Academia Sinica Formosan Language Archive"/>
-    <!--<provider url="http://victoria.linguistlist.org/php4/ore/XMLnamespacefiles/Krebs/Krebs.xml" static="true"
-	      name="Boiste"/>-->
-    <provider url="http://www.spectrum.uni-bielefeld.de/langdoc/olac.xml" static="true"
-	      name="U Bielefeld Language Archive"/>
-    <provider url="http://linguistlist.org/olac/metadata-catalog.cfm"
-	      name="The LINGUIST List Language Resources"/>
-    <!--<provider url="http://victoria.linguistlist.org/php4/ore/XMLnamespacefiles/mbcarrom/mbcarrom.xml" static="true"
-	      name="Magoria Books' Carib and Romani Archive"/>-->
-    <provider url="http://catalog.paradisec.org.au/oai/item"
-	      name="Pacific And Regional Archive for Digital Sources in Endangered Cultures (PARADISEC)"/>
+    <provider url="http://www.elra.info/elrac/elra_catalogue.xml" static="true" name="European Language Resources Association"/>
+    <provider url="http://linguistlist.org/olac/metadata-catalog.cfm" name="The LINGUIST List Language Resources"/>
+    <provider url="http://catalog.paradisec.org.au/oai/item" name="Pacific And Regional Archive for Digital Sources in Endangered Cultures (PARADISEC)"/>
     <provider url="http://www.language-archives.org/hosted/rosettaproject.org.xml" static="true"/>
-    <provider url="http://archive.ethnologue.com/sil_archives.asp" scenario="ListIdentifiers"/>
-    <provider url="http://www.language-archives.org/hosted/AcademiaSinica.xml" static="true"
-	      name="Academia Sinica Balanced Corpus of Modern Chinese"/>
-    <provider url="http://www.language-archives.org/hosted/tdproject.xml" static="true"
-	      name="The Typological Database Project"/>
-  	<provider url="https://catalog.ldc.upenn.edu/olac/ldc_catalog.xml" static="true"
-  	      name="The LDC Corpus Catalog"/>
-    <provider url="http://www.language-archives.org/hosted/alma.xml" static="true"
-	      name="African Language Materials Archive"/>
-    <provider url="http://wals.info/languoid/oai"
-	      name="WALS Online"/>
-    <provider url="http://wals.info/refdb_oai"
-	      name="WALS RefDB"/>
-    <!--<provider url="http://www.morphology.surrey.ac.uk/smg-metadata.xml" static="true"
-	      name="Surrey Morphology Group Databases"/>-->
-    <!--<provider url="http://www.language-archives.org/hosted/SinicaCorpus.xml" static="true"
-	      name="Academia Sinica Collections"/>-->
-    <provider url="http://scholarspace.manoa.hawaii.edu/Kaipuleohone.xml" static="true"
-	      name="ScholarSpace at University of Hawaii at Manoa"/>
-    <!--<provider url="http://www.language-archives.org/hosted/EarlyMandarin.xml" static="true"
-	      name="Academia Sinica Tagged Corpus of Early Mandarin Chinese"/>-->
-    <provider url="http://www.language-archives.org/hosted/thdl-olac.xml" static="true"
-	      name="The Tibetan and Himalayan Library"/>
-    <!--<provider url="http://nlp.pwr.wroc.pl/clarin/oai/oai2.php"
-	      name="University of Wroclaw"/>-->
-    <!--<provider url="http://iula02v.upf.edu/oai/oai.pl"
-	      name="UPF Harvesting Day Repository"/>-->
-    <provider url="http://ws02.iula.upf.edu/corpus_data/oai-iula/oai.pl"
-	      name="IULA-UPF Centre de Competència CLARIN"/>
-    <provider url="http://sli.uvigo.es/granxa/oai.pl/"
-	      name="Universidade de Vigo"/>
-    <provider url="http://ixa2.si.ehu.es/harvesting/oai/oai.pl"
-	      name="Euskal Herriko Unibertsitatea"/>
-   <!-- <provider url="http://www.talp.cat/oai/oai.pl"
-	      name="Universitat Politècnica de Catalunya"/>-->
-    <provider url="http://std.metu.edu.tr/cgi-bin/oai/oai.pl"
-	      name="Middle East Technical University"/>
-    <provider url="http://161.116.36.206/~publicacions/oai/oai.pl"
-	      name="Universitat de Barcelona"/>
-    <!--<provider url="http://nl2.ijs.si/oai/oai.pl"
-	      name="Jožef Stefan Institute"/>-->
-    <!--<provider url="http://xixona.dlsi.ua.es/cgi-bin/oai/oai.pl"
-	      name="Universitat d'Alacant"/>-->
-    <provider url="http://korpling.german.hu-berlin.de/oai/"
-	      name="Humboldt University of Berlin"/>
-    <provider url="http://oai.ir-facility.org/oai.pl"
-	      name="Information Retrieval Facility"/>
-    <!--<provider url="http://nactem.ac.uk/software/Farm/oai/oai.pl"
-	      name="National Centre for Text Mining NaCTeM"/>-->
-    <!--<provider url="http://services.gate.ac.uk/oai"
-	      name="University of Sheffield"/>-->
-    <provider url="http://sag.art.uniroma2.it/oai/oai.pl"
-	      name="University of Roma Tor Vergata"/>
-    <provider url="http://redac.univ-tlse2.fr/metadata/oai/oai.pl"
-	      name="CLLE-ERSS Université de Toulouse-Le Mirail"/>
-    <provider url="http://langtech1.ilc.cnr.it:8152/fedora/oai"
-	      name="Meta-Share Repository at ILC"/>
-    <provider url="http://aholab.ehu.es/oai/"
-	      name="University of the Basque Country"/>
-    <provider url="http://lrl-diffusion.univ-bpclermont.fr/mulce/metadata/repository/mulce-sr.xml" static="true"
-	      name="Multimodal Learning and teaching Corpora Exchange"/>
-    <!--<provider url="http://www.fihrist.org.uk/oaipmh"
-	      name="Fihrist"/>-->
-    <provider url="http://oai.hab.de/" name="Wolfenbuettel Digital Library" scenario="ListIdentifiers"/>
+    <provider url="https://catalog.ldc.upenn.edu/olac/ldc_catalog.xml" static="true" name="The LDC Corpus Catalog"/>
+    <provider url="http://wals.info/languoid/oai" name="WALS Online"/>
+    <provider url="http://wals.info/refdb_oai" name="WALS RefDB"/>
+    <provider url="http://ws02.iula.upf.edu/corpus_data/oai-iula/oai.pl" name="IULA-UPF Centre de Competència CLARIN"/>
+    <provider url="http://redac.univ-tlse2.fr/metadata/oai/oai.pl" name="CLLE-ERSS Université de Toulouse-Le Mirail"/>
+    <provider url="http://aholab.ehu.es/oai/" name="University of the Basque Country"/>
     <provider url="http://www.e-codices.unifr.ch/oai/oai.php?verb=Identify"/>
     <provider url="http://gei-digital.gei.de/viewer/oai?verb=Identify" name="GEI historic German textbooks"/>
-   <provider url="https://b2share.eudat.eu/api/oai2d" name="B2SHARE">
+    <provider url="https://b2share.eudat.eu/api/oai2d" name="B2SHARE">
       <set>0afede87-2bf2-4d89-867e-d2ee57251c62</set>
     </provider>
-    <provider url="https://repository.ortolang.fr/api/oai"/>
+    <!-- 
+      CHECK: timeouts
+    -->
+    <provider url="http://www.spectrum.uni-bielefeld.de/langdoc/olac.xml" static="true" name="U Bielefeld Language Archive"/>
+    <provider url="http://161.116.36.206/~publicacions/oai/oai.pl" name="Universitat de Barcelona"/>
+    <provider url="http://langtech1.ilc.cnr.it:8152/fedora/oai" name="Meta-Share Repository at ILC"/>
+    <!--
+      CHECK: tech problems
+    -->
+    <provider url="http://oai.hab.de/" name="Wolfenbuettel Digital Library"/>
   </providers>
 </config>

--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -83,7 +83,6 @@
     <provider url="https://catalog.ldc.upenn.edu/olac/ldc_catalog.xml" static="true" name="The LDC Corpus Catalog"/>
     <provider url="http://wals.info/languoid/oai" name="WALS Online"/>
     <provider url="http://wals.info/refdb_oai" name="WALS RefDB"/>
-    <provider url="http://ws02.iula.upf.edu/corpus_data/oai-iula/oai.pl" name="IULA-UPF Centre de Competència CLARIN"/>
     <provider url="http://redac.univ-tlse2.fr/metadata/oai/oai.pl" name="CLLE-ERSS Université de Toulouse-Le Mirail"/>
     <provider url="http://aholab.ehu.es/oai/" name="University of the Basque Country"/>
     <provider url="http://www.e-codices.unifr.ch/oai/oai.php?verb=Identify"/>

--- a/config-test-test.xml
+++ b/config-test-test.xml
@@ -48,7 +48,7 @@
       <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
     </format>
     <format match="namespace" value="http://www.clarin.eu/cmd/">
-      <action type="transform" file="resources/filter.xsl"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/filter.xsl"/>
       <action type="save" dir="oai" suffix=".xml"/>
       <action type="split"/>
       <action type="save" dir="rec" suffix=".xml"/>
@@ -58,9 +58,9 @@
       <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
     </format>
     <format match="prefix" value="olac">
-      <action type="transform" file="resources/filter.xsl"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/filter.xsl"/>
       <action type="save" dir="oai" suffix=".xml"/>
-      <action type="transform" file="resources/addOAISetName.xsl" cache=".oai-cache"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/addOAISetName.xsl" cache=".oai-cache"/>
       <action type="split"/>
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>
@@ -69,9 +69,9 @@
       <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
     </format>
     <format match="prefix" value="oai_dc">
-      <action type="transform" file="resources/filter.xsl"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/filter.xsl"/>
       <action type="save" dir="oai" suffix=".xml"/>
-      <action type="transform" file="resources/addOAISetName.xsl" cache=".oai-cache"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/addOAISetName.xsl" cache=".oai-cache"/>
       <action type="split"/>
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>

--- a/config-test-test.xml
+++ b/config-test-test.xml
@@ -40,7 +40,7 @@
   <!-- ### actions to take on metadata formats (in order of preference) ### -->
   <actions>
     <format match="namespace" value="http://www.clarin.eu/cmd/1">
-      <action type="transform" file="resources/filter.xsl"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/filter.xsl"/>
       <action type="save" dir="oai" suffix=".xml"/>
       <action type="split"/>
       <action type="save" dir="rec" suffix=".xml"/>
@@ -60,7 +60,7 @@
     <format match="prefix" value="olac">
       <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/filter.xsl"/>
       <action type="save" dir="oai" suffix=".xml"/>
-      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/addOAISetName.xsl" cache=".oai-cache"/>
+      <action type="transform" file="resources/addOAISetName.xsl" cache=".oai-cache"/>
       <action type="split"/>
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>
@@ -71,7 +71,7 @@
     <format match="prefix" value="oai_dc">
       <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/filter.xsl"/>
       <action type="save" dir="oai" suffix=".xml"/>
-      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/oai-harvest-config/develop/addOAISetName.xsl" cache=".oai-cache"/>
+      <action type="transform" file="resources/addOAISetName.xsl" cache=".oai-cache"/>
       <action type="split"/>
       <action type="save" dir="rec" suffix=".xml"/>
       <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>

--- a/config-test-test.xml
+++ b/config-test-test.xml
@@ -1,0 +1,118 @@
+<!-- This is the configuration for CLARIN harvesting. -->
+<config>
+
+  <!-- ### configuration settings ### -->
+  <settings>
+    <!-- Working directory. -->
+    <workdir>/home/kj/temp/oai/workspace</workdir>
+
+    <!-- Maximum number of attempts per record before giving up. -->
+    <max-retry-count>2</max-retry-count>
+
+    <!-- Delay between retries of a record (milliseconds). -->
+    <retry-delay>10000</retry-delay>
+
+    <!-- Maximum number of concurrent harvester threads -->
+    <max-jobs>4</max-jobs>
+
+    <!-- Number of resources placed in the resource pool. -->
+    <resource-pool-size>4</resource-pool-size>
+
+    <!-- Default timeout (for connection and reading) for a single
+    http request in seconds. If unspecified, will be INFINITE.  -->
+    <timeout>60</timeout>
+    <scenario>ListRecords</scenario>
+    <incremental>false</incremental>
+  </settings>
+
+  <!-- ### output directories (referenced in the action section) ### -->
+  <directories>
+    <!-- When the attribute 'max-files' is non-zero, subdirectories
+         will be created to ensure no directory has more than that
+         number of files. -->
+    <dir path="oai-rec" id="rec" max-files="0"/>
+    <dir path="oai-pmh" id="oai" max-files="0"/>
+    <dir path="results/cmdi-1_1" id="cmdi-1_1" max-files="0"/>
+    <dir path="results/cmdi" id="cmdi-1_2" max-files="0"/>
+  </directories>
+  
+  
+  <!-- ### actions to take on metadata formats (in order of preference) ### -->
+  <actions>
+    <format match="namespace" value="http://www.clarin.eu/cmd/1">
+      <action type="transform" file="resources/filter.xsl"/>
+      <action type="save" dir="oai" suffix=".xml"/>
+      <action type="split"/>
+      <action type="save" dir="rec" suffix=".xml"/>
+      <action type="strip"/>
+      <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
+    </format>
+    <format match="namespace" value="http://www.clarin.eu/cmd/">
+      <action type="transform" file="resources/filter.xsl"/>
+      <action type="save" dir="oai" suffix=".xml"/>
+      <action type="split"/>
+      <action type="save" dir="rec" suffix=".xml"/>
+      <action type="strip"/>
+      <action type="save" dir="cmdi-1_1" suffix=".xml"/>
+      <action type="transform" file="https://infra.clarin.eu/CMDI/1.x/upgrade/cmd-record-1_1-to-1_2.xsl" cache=".oai-cache"/>
+      <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
+    </format>
+    <format match="prefix" value="olac">
+      <action type="transform" file="resources/filter.xsl"/>
+      <action type="save" dir="oai" suffix=".xml"/>
+      <action type="transform" file="resources/addOAISetName.xsl" cache=".oai-cache"/>
+      <action type="split"/>
+      <action type="save" dir="rec" suffix=".xml"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>
+      <action type="save" dir="cmdi-1_1" suffix=".xml"/>
+      <action type="transform" file="https://infra.clarin.eu/CMDI/1.x/upgrade/cmd-record-1_1-to-1_2.xsl" cache=".oai-cache"/>
+      <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
+    </format>
+    <format match="prefix" value="oai_dc">
+      <action type="transform" file="resources/filter.xsl"/>
+      <action type="save" dir="oai" suffix=".xml"/>
+      <action type="transform" file="resources/addOAISetName.xsl" cache=".oai-cache"/>
+      <action type="split"/>
+      <action type="save" dir="rec" suffix=".xml"/>
+      <action type="transform" file="https://raw.githubusercontent.com/clarin-eric/metadata-conversion/olac-cmdi/olac-cmdi/olac2cmdi.xsl"/>
+      <action type="save" dir="cmdi-1_1" suffix=".xml"/>
+      <action type="transform" file="https://infra.clarin.eu/CMDI/1.x/upgrade/cmd-record-1_1-to-1_2.xsl" cache=".oai-cache"/>
+      <action type="save" dir="cmdi-1_2" suffix=".xml" history="true"/>
+    </format>
+  </actions>
+  
+  <!-- ### list of providers ### -->
+  <providers>
+    <!--<provider url="http://archief.meertens.knaw.nl/oaiprovider/"/>
+    <provider url="http://www.elra.info/elrac/elra_catalogue.xml" static="true"
+	      name="European Language Resources Association"/>
+    <provider url="http://catalog.paradisec.org.au/oai/item"
+	      name="Pacific And Regional Archive for Digital Sources in Endangered Cultures (PARADISEC)"/>
+    <provider url="https://b2share.eudat.eu/oai2d/" name="B2SHARE">
+      <set>Linguistics</set>
+    </provider>
+    <provider url="http://clarino.uib.no/oai"/>
+    <provider url="https://repo.clarino.uib.no/oai/request"/>
+    <provider url="http://catalog.paradisec.org.au/oai/item"
+      name="Pacific And Regional Archive for Digital Sources in Endangered Cultures (PARADISEC)"/>
+    <provider url="https://lindat.mff.cuni.cz/repository/oai/request"/>
+    <provider url="https://arche.acdh.oeaw.ac.at/oai"/>
+    <provider url="https://clarinportulan.net/oaipmh/"/>
+    <provider url="https://www.meertens.knaw.nl/flat/oai2"/>
+    <provider url="http://www.meertens.knaw.nl/oai/oai_server.php"/>
+    <provider url="http://clarino.uib.no/oai"/>
+    <provider url="https://lindat.mff.cuni.cz/repository/oai/request"/>
+    <provider url="https://oai.cedifor.de/"/>
+    <provider url="https://www.meertens.knaw.nl/flat/oai2"/>
+-->
+<!--
+    <provider url="https://oai.datacite.org/oai">
+      <filter>Subject and Keywords = Humanities - Languages and literature (6.2) or Humanities - Other humanities (6.5))</filter>
+      <set>DELFT.UU</set>
+    </provider>
+-->
+    <provider url="https://www.meertens.knaw.nl/flat/oai2">
+      <filter>dwangarbeider</filter>
+    </provider>
+  </providers>
+</config>

--- a/filter.xsl
+++ b/filter.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:oai="http://www.openarchives.org/OAI/2.0/">
+
+    <xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
+    
+    <xsl:param name="provider_uri" select="()"/>
+    <xsl:param name="config" select="()"/>
+    
+    <xsl:template match="/" priority="1">
+        <xsl:copy>
+            <xsl:apply-templates>
+                <xsl:with-param name="filter" tunnel="yes" select="exists($config//provider[@url=$provider_uri]/filter)"/>
+            </xsl:apply-templates>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="oai:record">
+        <xsl:param name="filter" tunnel="yes"/>
+        <xsl:variable name="rec" select="."/>
+        <xsl:comment>DBG: provider_uri[<xsl:value-of select="$provider_uri"/>] filter[<xsl:value-of select="$filter"/>] [<xsl:value-of select="$config//provider[@url=$provider_uri]/filter"/>]</xsl:comment>
+        <xsl:choose>
+            <xsl:when test="$filter">
+                <xsl:if test="$rec//*:title[contains(.,$config//provider[@url=$provider_uri]/filter)]">
+                    <xsl:next-match/>
+                </xsl:if>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:next-match/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="node() | @*">
+        <xsl:copy>
+            <xsl:apply-templates select="node() | @*"/>
+        </xsl:copy>
+    </xsl:template>
+        
+</xsl:stylesheet>


### PR DESCRIPTION
UPF endpoint is registered in the centre registry (see https://centres.clarin.eu/oai_pmh)