### PR TITLE
remove ACL anthology

### DIFF
--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -74,7 +74,6 @@
 
   <!-- ### list of providers ### -->
   <providers>
-    <provider url="http://www.language-archives.org/hosted/acl.xml" static="true" name="A Digital Archive of Research Papers in Computational Linguistics"/>
     <provider url="http://cla.berkeley.edu/olac.xml" static="true"/>
     <provider url="http://www.elra.info/elrac/elra_catalogue.xml" static="true" name="European Language Resources Association"/>
     <provider url="http://linguistlist.org/olac/metadata-catalog.cfm" name="The LINGUIST List Language Resources"/>


### PR DESCRIPTION
The old ACL anthology (http://www.aclweb.org/old_anthology/) has been replaced by a new version (https://www.aclweb.org/anthology/) that does no longer support OAI-PMH (https://github.com/acl-org/acl-anthology/issues/21). While the old OAI records remain available, this means this provider is becoming more and more obsolete. At the same time, since it is providing access to papers, and not to language data, it is a good opportunity to clean up the VLO and thus to remove this metadata source.