### PR TITLE
Configuration override for ACDH endpoint

### DIFF
--- a/config-clarin-clarin.xml
+++ b/config-clarin-clarin.xml
@@ -110,6 +110,8 @@
       -->
       <!-- MPI sometimes needs a bit more time -->
       <config url="https://archive.mpi.nl/oai2" max-retry-count="5" retry-delay="10 30 60 360"/>
+      <!-- ACDH/ARCHE needs some time to gerenate the metadata -->
+      <config url="http://arche.acdh.oeaw.ac.at/oai" timeout="300" />
       <!-- Leipzig doesn't like too much time between calls within one session, GetRecord calls don't care -->
       <config url="https://clarinoai.informatik.uni-leipzig.de/oaiprovider/oai" scenario="ListIdentifiers"/>
       <!-- BAS runs sometimes into memory problems when its big CMD records get processed in batch -->


### PR DESCRIPTION
ACDH/ARCHE endpoint needs more time to generate metadata; config override that sets timeout to 300s (5min)