### PR TITLE
Adaptations for harvest manager v1.1.0

### DIFF
--- a/config-clarin-clarin.xml
+++ b/config-clarin-clarin.xml
@@ -95,6 +95,8 @@
   <providers>
     <import>
       <registry url="https://centres.clarin.eu/api/model"/>
+      <includeOaiPmhSetTypes>*</includeOaiPmhSetTypes>
+      <excludeOaiPmhSetTypes>WebLicht</excludeOaiPmhSetTypes>
       <!--
         Block harvesting from a specific provider defined in the registry 
         element by supplying its endpoint URL as an child element tagged 


### PR DESCRIPTION
Updated CLARIN configuration to work with new features of harvest manager 1.1. 

See https://github.com/clarin-eric/oai-harvest-manager/issues/26 and https://github.com/clarin-eric/oai-harvest-config/pull/10/files


Add this information, now removed from the configuration, to the centre registry when merging:

```xml
    <provider url="https://arche.acdh.oeaw.ac.at/oai" timeout="300">
      <set>clarin-vlo</set>
    </provider>
```

```xml
    <provider url="https://dataverse.no/oai">
      <set>trolling</set>
    </provider>
```