### PR TITLE
Remove SOAS from config-clarin-clarin.xml

### DIFF
--- a/config-clarin-clarin.xml
+++ b/config-clarin-clarin.xml
@@ -140,9 +140,10 @@
     <provider url="https://dataverse.no/oai">
       <set>trolling</set>
     </provider>
-    <provider url="https://lat1.lis.soas.ac.uk/ds/oaiprovider/oai2"/>
+
     <provider url="https://arche.acdh.oeaw.ac.at/oaipmh/" timeout="300">
       <set>clarin-vlo</set>
     </provider>
+	  
   </providers>
 </config>


### PR DESCRIPTION
Removed SOAS (moved to new repository system, requires auth)