### PR TITLE
Clean out 'external' providers

### DIFF
--- a/config-clarin-clarin.xml
+++ b/config-clarin-clarin.xml
@@ -9,7 +9,7 @@
     <!-- Maximum number of attempts per record before giving up. -->
     <max-retry-count>2</max-retry-count>
 
-    <!-- Delay between retries of a record (milliseconds). -->
+    <!-- Delay between retries of a record (seconds). -->
     <retry-delay>10</retry-delay>
 
     <!-- Maximum number of concurrent harvester threads -->
@@ -113,7 +113,7 @@
       <!-- MPI sometimes needs a bit more time -->
       <config url="https://archive.mpi.nl/oai2" max-retry-count="5" retry-delay="10 30 60 360"/>
       <!-- ACDH/ARCHE needs some time to gerenate the metadata -->
-      <!-- <config url="http://arche.acdh.oeaw.ac.at/oai" timeout="300" /> -->
+      <config url="https://arche.acdh.oeaw.ac.at/oaipmh/" timeout="300" />
       <!-- Leipzig doesn't like too much time between calls within one session, GetRecord calls don't care -->
       <config url="https://clarinoai.informatik.uni-leipzig.de/oaiprovider/oai" scenario="ListIdentifiers"/>
       <!-- BAS runs sometimes into memory problems when its big CMD records get processed in batch -->
@@ -122,29 +122,6 @@
       <config url="http://oai.talkbank.org/oai/provider" scenario="ListIdentifiers"/>
     </import>
     <!-- Virtual Collection Registry -->
-     <provider url="https://collections.clarin.eu/oai"/> 
-    <!--
-     In addition to the registry entries, there are some "D centres" that
-	   don't belong in the centre registry. They are manually included here.
-	   If one is later added to the registry the entry should be removed from
-	   this file.
-
-     Currently included:
-     - Utrecht University Library and Het Nederlands
-     - Instituut voor Beeld en Geluid.
-    
-    <provider url="http://dspace.library.uu.nl/oai/clarin"/>
-    <provider url="http://oai.beeldengeluid.nl/academia/oai"/>
-    -->
-    
-    <!-- extra -->
-
-    <provider url="https://dataverse.no/oai">
-      <set>trolling</set>
-    </provider>
-    
-    <provider url="https://arche.acdh.oeaw.ac.at/oaipmh/" timeout="300">
-      <set>clarin-vlo</set>
-    </provider>
+     <provider url="https://collections.clarin.eu/oai"/>
   </providers>
 </config>


### PR DESCRIPTION
Providers with sets specified can now be configured in the centre registry, and are picked up by the harvester

- ACDH (url: `https://arche.acdh.oeaw.ac.at/oaipmh/`, sets: `clarin-vlo`)
- Trolling (url: `https://dataverse.no/oai`; sets: `trolling`)