### PR TITLE
Configure Swedish national data service and Language bank

### DIFF
--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -130,14 +130,18 @@
       CHECK: tech problems
     -->
     <provider url="http://oai.hab.de/" name="Wolfenbuettel Digital Library"/>
-    <provider url="https://oai.datacite.org/oai" name="YODA repository at Utrecht University">
+    <provider url="https://oai.datacite.org/oai" name="DataCite">
         <!--
+           YODA repository at Utrecht University
+      
            Set with additional filtering through custom query, see 
            https://support.datacite.org/docs/datacite-oai-pmh#section-arbitrary-queries
            
            base64('subjects.subject:(*6.2* OR *6.5*)') = c3ViamVjdHMuc3ViamVjdDooKjYuMiogT1IgKjYuNSop
         -->
         <set>DELFT.UU~c3ViamVjdHMuc3ViamVjdDooKjYuMiogT1IgKjYuNSop</set>
+        <!-- Swedish Language Bank -->
+        <set>SND.SPRKB</set>
     </provider>
     <provider url="https://snd.se/oai-pmh" name="Swedish National Data Service">
         <!-- ISOF, see https://sprakresurser.isof.se/ -->

--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -139,5 +139,11 @@
         -->
         <set>DELFT.UU~c3ViamVjdHMuc3ViamVjdDooKjYuMiogT1IgKjYuNSop</set>
     </provider>
+    <provider url="https://snd.se/oai-pmh" name="Swedish National Data Service">
+        <!-- ISOF, see https://sprakresurser.isof.se/ -->
+        <set>principal:isof.se</set>
+        <!-- subject "Language technology" -->
+        <set>subject:ssif:10208</set>
+    </provider>
   </providers>
 </config>


### PR DESCRIPTION
Harvesting of
* ISOF and SND Language technology records from SND
* Språkbanken from DataCite.org