### PR TITLE
Cleanup of 'others' harvest config

### DIFF
--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -115,7 +115,7 @@
   <providers>
     <provider url="http://cla.berkeley.edu/olac.xml" static="true"/>
     <provider url="http://www.elra.info/elrac/elra_catalogue.xml" static="true" name="European Language Resources Association"/>
-    <provider url="http://linguistlist.org/olac/metadata-catalog.cfm" name="The LINGUIST List Language Resources"/>
+    <provider url="http://www.language-archives.org/cgi-bin/olaca3.pl" name="The LINGUIST List Language Resources"/>
     <provider url="http://catalog.paradisec.org.au/oai/item" name="Pacific And Regional Archive for Digital Sources in Endangered Cultures (PARADISEC)"/>
     <provider url="http://www.language-archives.org/hosted/rosettaproject.org.xml" static="true"/>
     <provider url="https://catalog.ldc.upenn.edu/olac/ldc_catalog.xml" static="true" name="The LDC Corpus Catalog"/>

--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -133,7 +133,6 @@
       CHECK: timeouts
     -->
     <provider url="http://161.116.36.206/~publicacions/oai/oai.pl" name="Universitat de Barcelona"/>
-    <provider url="http://langtech1.ilc.cnr.it:8152/fedora/oai" name="Meta-Share Repository at ILC"/>
     <!--
       CHECK: tech problems
     -->

--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -132,7 +132,6 @@
     <!-- 
       CHECK: timeouts
     -->
-    <provider url="http://www.spectrum.uni-bielefeld.de/langdoc/olac.xml" static="true" name="U Bielefeld Language Archive"/>
     <provider url="http://161.116.36.206/~publicacions/oai/oai.pl" name="Universitat de Barcelona"/>
     <provider url="http://langtech1.ilc.cnr.it:8152/fedora/oai" name="Meta-Share Repository at ILC"/>
     <!--


### PR DESCRIPTION
* Configured endpoint for Linguist List was broken. I think that http://www.language-archives.org/cgi-bin/olaca3.pl can be considered as a replacement but this needs to be confirmed
* Broken endpoints [U Bielefeld Language Archive](http://www.spectrum.uni-bielefeld.de/langdoc/olac.xml) and [Meta-Share Repository at ILC](http://langtech1.ilc.cnr.it:8152/fedora/oai) removed
  * The latter can probably be considered to have been replaced by the [endpoint](http://dspace-clarin-it.ilc.cnr.it/repository/oai/request) that is registered in the centre registry for [ILC4CLARIN](https://centres.clarin.eu/centre/34)