### PR TITLE
Removed Språkbanken set from datacite.org harvest

### DIFF
--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -149,8 +149,6 @@
            base64('subjects.subject:(*6.2* OR *6.5*)') = c3ViamVjdHMuc3ViamVjdDooKjYuMiogT1IgKjYuNSop
         -->
         <set>DELFT.UU~c3ViamVjdHMuc3ViamVjdDooKjYuMiogT1IgKjYuNSop</set>
-        <!-- Swedish Language Bank -->
-        <set>SND.SPRKB</set>
     </provider>
     <provider url="https://snd.se/oai-pmh" name="Swedish National Data Service">
         <!-- ISOF, see https://sprakresurser.isof.se/ -->


### PR DESCRIPTION
We have received the request to disable harvesting of SND/Språkbanken metadata from the DataCite.org provider:

> Thanks for noticing this! We have recently started a migration of our metadata from DSpace to DataCite, so please disable the dspace harvesting, to avoid duplication.