### PR TITLE
Remove Språkbanken entry from Datacite provider

### DIFF
--- a/config-others-others.xml
+++ b/config-others-others.xml
@@ -159,9 +159,6 @@
            base64('prefix:10.34973 AND ((identifiers.identifier:*/rich/* OR identifiers.identifier:*/cls/*) AND NOT((rightsList.rightsUri:*closedAccess)))')
         -->
         <set>DELFT.RU~cHJlZml4OjEwLjM0OTczIEFORCAoKGlkZW50aWZpZXJzLmlkZW50aWZpZXI6Ki9yaWNoLyogT1IgaWRlbnRpZmllcnMuaWRlbnRpZmllcjoqL2Nscy8qKSBBTkQgTk9UKChyaWdodHNMaXN0LnJpZ2h0c1VyaToqY2xvc2VkQWNjZXNzKSkp</set>
-      
-        <!-- Swedish Language Bank (unfiltered) -->
-        <set>SND.SPRKB</set>
     </provider>
     <provider url="https://api.researchdata.se/oai-pmh" name="Swedish National Data Service">
         <!-- ISOF, see https://sprakresurser.isof.se/ -->


### PR DESCRIPTION
Removed the Swedish Language Bank entry from the "others" configuration.